### PR TITLE
Add Structured Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank_issue.yml
+++ b/.github/ISSUE_TEMPLATE/blank_issue.yml
@@ -1,0 +1,18 @@
+name: Blank Issue
+description: Open a free-form issue when none of the templates fit.
+title: "[Blank]: "
+labels:
+  - blank
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template only if the other templates do not apply.
+  - type: textarea
+    id: details
+    attributes:
+      label: Issue Details
+      description: Describe the issue in your own format.
+      placeholder: Add context, links, logs, or any relevant information.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,47 @@
+name: Bug Report
+description: Report something that is broken or not working as expected.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Bug Summary
+      description: What went wrong?
+      placeholder: A clear and short description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: List exact steps so we can reproduce the issue.
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. See error ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      placeholder: Describe what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      placeholder: Describe what actually happened.
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser/OS/device or deployment environment.
+      placeholder: e.g. Chrome 121 on Windows 11, Render production
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,30 @@
+name: Enhancement
+description: Suggest an improvement to an existing feature or flow.
+title: "[Enhancement]: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: current_behavior
+    attributes:
+      label: Current Behavior
+      description: What exists today?
+      placeholder: Describe current behavior or limitation.
+    validations:
+      required: true
+  - type: textarea
+    id: improvement
+    attributes:
+      label: Suggested Improvement
+      description: What should be improved?
+      placeholder: Describe the improvement and expected behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Why This Matters
+      description: Explain the benefit of this improvement.
+      placeholder: Performance, UX, maintainability, reliability, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/new_feature.yml
+++ b/.github/ISSUE_TEMPLATE/new_feature.yml
@@ -1,0 +1,38 @@
+name: New Feature
+description: Propose a brand-new feature for the project.
+title: "[Feature]: "
+labels:
+  - feature
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or Opportunity
+      description: What user problem should this feature solve?
+      placeholder: Explain the problem this feature addresses.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed Feature
+      description: Describe your solution idea clearly.
+      placeholder: Describe the feature, behavior, and user flow.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternatives or other approaches?
+      placeholder: Mention other options you considered.
+    validations:
+      required: false
+  - type: textarea
+    id: impact
+    attributes:
+      label: Expected Impact
+      description: Who benefits and how?
+      placeholder: Explain expected outcome or value.
+    validations:
+      required: false


### PR DESCRIPTION
Adds simple, structured issue templates under [ISSUE_TEMPLATE] to standardize reports and speed up triage.

Added:
blank_issue.yml, bug_report.yml, enhancement.yml, new_feature.yml, config.yml

closes: #30

@mishthimahajan  plz review it