### PR TITLE
Add API Rate Limiting to Backend for Security

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -2,6 +2,7 @@ import express from "express";
 import mongoose from "mongoose";
 import cors from "cors";
 import bodyParser from "body-parser";
+import rateLimit from "express-rate-limit";
 import router from "./routes/index.js";
 
 const app = express();
@@ -14,6 +15,29 @@ app.use(cors({
 })); // Allow requests from frontend
 app.use(express.json());
 app.use(bodyParser.urlencoded({ extended: true }));
+
+// Global rate limiter: 100 requests per 15 minutes per IP
+const apiLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+  legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+  message: { message: "Too many requests from this IP, please try again later." },
+});
+
+// Stricter limiter for auth endpoints to prevent brute-force
+const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 5, // limit each IP to 5 requests per windowMs
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { message: "Too many authentication attempts, please try again later." },
+});
+
+// Apply global limiter to all requests
+app.use(apiLimiter);
+
+// NOTE: auth-specific limiter moved to route-level in routes/index.js
 
 
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,8 +4,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-     "start": "node ./bin/www",
-  "dev": "nodemon ./bin/www"
+    "start": "node ./bin/www",
+    "dev": "nodemon ./bin/www"
   },
   "type": "module",
   "keywords": [],
@@ -18,6 +18,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
     "express": "^5.1.0",
+    "express-rate-limit": "^8.2.1",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.19.1"
   }

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -1,6 +1,7 @@
 
 
 import express, { response } from "express";
+import rateLimit from "express-rate-limit";
 const router = express.Router();
 import User from "../models/User.js";
 import Food from "../models/food.js";
@@ -9,6 +10,15 @@ import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
 import authenticateToken from "../middleware/auth.js";
 import FoodRequest from "../models/foodrequest.js";
+
+// Stricter limiter for auth endpoints to prevent brute-force
+const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 5, // limit each IP to 5 requests per windowMs
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { message: "Too many authentication attempts, please try again later." },
+});
 
 router.get("/receiver/data", authenticateToken, async (req, res) => {
   try {
@@ -69,7 +79,7 @@ router.get("/donor/data", authenticateToken, async (req, res) => {
   }
 });
 
-router.post("/register", async (req, res) => {
+router.post("/register", authLimiter, async (req, res) => {
   try {
     const { fullName, email, password, role } = req.body;
 
@@ -103,7 +113,7 @@ router.post("/register", async (req, res) => {
 
 
 
-router.post("/login", async (req, res) => {
+router.post("/login", authLimiter, async (req, res) => {
   try {
     const { email, password } = req.body;
 


### PR DESCRIPTION
What’s Added

- Integrated express-rate-limit middleware
- Added global rate limiter for /api routes
- Added stricter rate limiter for /api/auth routes
- Returns HTTP 429 when limit is exceeded

🎯 Why This Change

- Prevents brute force attacks
- Reduces spam and abuse
- Protects server from heavy request load
- Improves overall API stability

🚀 Result

- Backend is more secure
- Better protection for authentication routes
- More production ready setup


closes: #51


@mishthimahajan  plz review it